### PR TITLE
fixed typo on ad_select and added to RedHat (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ address obtained via DHCP.
               bond_mode: 802.3ad
               bond_miimon: 100
               bond_slaves: [eth1, eth2]
+              bond_ad_select: 2
 
 5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface
 

--- a/templates/RedHat_bond_options.j2
+++ b/templates/RedHat_bond_options.j2
@@ -14,6 +14,9 @@ BONDING_OPTS="mode={{ item.bond_mode }} miimon={{ item.bond_miimon|default(100) 
 {%- if item.bond_use_carrier is defined %}
  use_carrier={{ item.bond_use_carrier }}
 {%- endif -%}
+{%- if item.bond_ad_select is defined %}
+ ad_select={{ item.bond_ad_select }}
+{%- endif -%}
 {%- if item.bond_extra_opts is defined %}
  {{ item.bond_extra_opts }}
 {%- endif -%}

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -15,7 +15,7 @@ iface {{ item.device }} inet {% if item.bootproto is defined %}{{ item.bootproto
 {% endif %}
 {% if item.bond_mode == 2 or item.bond_mode == 'balance-xor'
    or item.bond_mode == 4 or item.bond_mode == '802.3ad'
-   or item.bond_mode == 6 or item.bond_mode == 'balance-tlb' 
+   or item.bond_mode == 6 or item.bond_mode == 'balance-tlb'
 %}
     bond-xmit-hash-policy  {{ item.bond_xmit_hash_policy | default('layer3+4') }}
 {% endif %}
@@ -27,7 +27,7 @@ iface {{ item.device }} inet {% if item.bootproto is defined %}{{ item.bootproto
     bond-updelay           {{ item.bond_updelay }}
 {% endif %}
 {% if item.bond_ad_select is defined %}
-    bond-ad-select         {{ item.bond_bond_ad_select }}
+    bond-ad-select         {{ item.bond_ad_select }}
 {% endif %}
 {% if item.bond_arp_interval is defined %}
     bond-arp-interval      {{ item.bond_arp_interval }}
@@ -81,4 +81,3 @@ iface {{ item.device }} inet6 static
 {% endfor %}
 {% endif %}
 {% endif %}
-


### PR DESCRIPTION
* changes deprecated install state

* Changes deprecated tests

* fixed typo for bond_ad_select

* added bond_ad_select to RHEL

* added bond_ad_select to example