### PR TITLE
When cidr is a /32 there is no broadcast

### DIFF
--- a/templates/Debian_ipv4_config.j2
+++ b/templates/Debian_ipv4_config.j2
@@ -2,7 +2,9 @@
     address                {{ item.cidr | ipaddr('address') }}
     network                {{ item.cidr | ipaddr('network') }}
     netmask                {{ item.cidr | ipaddr('netmask') }}
+{% if item.cidr | ipaddr('broadcast') %}
     broadcast              {{ item.cidr | ipaddr('broadcast') }}
+{% endif %}
 {% elif item.address is defined and item.netmask is defined %}
 {% if item.address is defined %}
     address                {{ item.address }}


### PR DESCRIPTION
Don't print the broadcast line if there isn't a broadcast address